### PR TITLE
Add selector

### DIFF
--- a/caMon.IPages/caMon.IPages.csproj
+++ b/caMon.IPages/caMon.IPages.csproj
@@ -8,6 +8,8 @@
     <Product>BIDS Project</Product>
     <Copyright>Copyright 2020 Tetsu Otter</Copyright>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/caMon.ISelector/ISelector.cs
+++ b/caMon.ISelector/ISelector.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace caMon
+{
+	public interface ISelector : IPages
+	{
+		/// <summary>別ページへの推移を要求するイベント</summary>
+		event EventHandler<PageChangeEventArgs> PageChangeRequest;
+	}
+
+	/// <summary>選択画面から実画面を表示するためのイベントで使用する引数のクラス</summary>
+	public class PageChangeEventArgs : EventArgs
+	{
+		/// <summary>次に表示するページ</summary>
+		public IPages NewPage;
+
+		/// <summary>次に表示するページが実装されたmodファイルへのパス</summary>
+		public string ModPath;
+	}
+}

--- a/caMon.ISelector/ModLoader.cs
+++ b/caMon.ISelector/ModLoader.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+
+namespace caMon
+{
+	public static class ModLoader
+	{
+		/// <summary>dllから指定の型を持つクラスをロードする</summary>
+		/// <typeparam name="T">ロードする型</typeparam>
+		/// <param name="FPath">dllへのパス</param>
+		/// <returns>読み込んだインスタンス</returns>
+		/// <exception cref="FileNotFoundException">指定のファイルが存在しなかった場合にthrowされる</exception>
+		/// <exception cref="EntryPointNotFoundException">指定のdllに指定のクラスが含まれていなかった場合にthrowされる</exception>
+		public static T LoadDllInst<T>(string FPath)
+		//ref : https://qiita.com/rita0222/items/609583c31cb7f0132086
+		{
+			if (!File.Exists(FPath))
+				throw new FileNotFoundException();
+
+			var types = Assembly.LoadFrom(FPath).GetTypes();
+
+			foreach(var t in types)
+			{
+				if (t.IsInterface)
+					continue;
+
+				if (Activator.CreateInstance(t) is T retval && retval != null)
+					return retval;
+			}
+
+			throw new EntryPointNotFoundException();
+		}
+	}
+}

--- a/caMon.ISelector/caMon.ISelector.csproj
+++ b/caMon.ISelector/caMon.ISelector.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<RootNamespace>caMon</RootNamespace>
+		<Authors>Tetsu Otter</Authors>
+		<Company>Tech Otter</Company>
+		<Product>BIDS Project</Product>
+		<Copyright>Copyright 2020 Tetsu Otter</Copyright>
+		<PackageLicenseFile>LICENSE</PackageLicenseFile>
+		<AssemblyVersion>1.0.0.0</AssemblyVersion>
+		<FileVersion>1.0.0.0</FileVersion>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<Reference Include="PresentationFramework">
+			<HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\PresentationFramework.dll</HintPath>
+		</Reference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="..\LICENSE">
+			<Pack>True</Pack>
+			<PackagePath></PackagePath>
+		</None>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\caMon.IPages\caMon.IPages.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/caMon.selector.default/AssemblyInfo.cs
+++ b/caMon.selector.default/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+
+[assembly: ThemeInfo(
+		ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
+																		 //(used if a resource is not found in the page,
+																		 // or application resource dictionaries)
+		ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
+																							//(used if a resource is not found in the page,
+																							// app, or any theme specific resource dictionaries)
+)]

--- a/caMon.selector.default/SelectPage.xaml
+++ b/caMon.selector.default/SelectPage.xaml
@@ -1,0 +1,65 @@
+﻿<Page x:Class="caMon.selector.default_.SelectPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			mc:Ignorable="d" 
+      Title="SelectPage">
+	<Viewbox>
+		<Grid Background="Black" Height="480" Width="640">
+			<Grid.RowDefinitions>
+				<RowDefinition Height="60"/>
+				<RowDefinition Height="*"/>
+				<RowDefinition Height="40"/>
+			</Grid.RowDefinitions>
+			<!--Row = 0-->
+			<Label Content="caMon default page selector" Foreground="White" Margin="10" FontSize="16" Grid.Row="0"/>
+			<Button Click="CloseBtn_Click"
+							Content="Close"
+							Margin="5"
+							Padding="5"
+							Width="60"
+							HorizontalAlignment="Right"
+							VerticalAlignment="Center"
+							Grid.Row="0"/>
+
+			<!--Row = 1-->
+			<Grid Grid.Row="1" Background="#444">
+				<ListView x:Name="ModsList_ListView"
+									Margin="5"
+									FontSize="8"
+									ItemsSource="{Binding Mode=OneWay}">
+					<ListView.View>
+						<GridView>
+							<GridViewColumn Header="Original File Name" DisplayMemberBinding="{Binding OriginalFilename}"/>
+							<GridViewColumn Header="Company Name" DisplayMemberBinding="{Binding CompanyName}"/>
+							<GridViewColumn Header="File Version" DisplayMemberBinding="{Binding FileVersion}"/>
+							<GridViewColumn Header="Description" DisplayMemberBinding="{Binding FileDescription}"/>
+							<GridViewColumn Header="Product Name" DisplayMemberBinding="{Binding ProductName}"/>
+							<GridViewColumn Header="Product Version" DisplayMemberBinding="{Binding ProductVersion}"/>
+							<GridViewColumn Header="IsPreRelease" DisplayMemberBinding="{Binding IsPreRelease}"/>
+							<GridViewColumn Header="File Path" DisplayMemberBinding="{Binding FileName}"/>
+						</GridView>
+					</ListView.View>
+				</ListView>
+			</Grid>
+			
+			<!--Row = 2-->
+			<Button Click="BackBtn_Click"
+							Content="Back"
+							Margin="5"
+							Padding="5"
+							Width="60"
+							HorizontalAlignment="Left"
+							Grid.Row="2"/>
+
+			<Button Click="LoadBtn_Click"
+							Content="Load the selected mod"
+							Margin="5"
+							Padding="5"
+							Width="300"
+							HorizontalAlignment="Center"
+							Grid.Row="2"/>
+		</Grid>
+	</Viewbox>
+</Page>

--- a/caMon.selector.default/SelectPage.xaml.cs
+++ b/caMon.selector.default/SelectPage.xaml.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace caMon.selector.default_
+{
+	/// <summary>
+	/// SelectPage.xaml の相互作用ロジック
+	/// </summary>
+	public partial class SelectPage : Page, ISelector
+	{
+		string SelectedPath = string.Empty;
+
+		public SelectPage()
+		{
+			InitializeComponent();
+
+			ModsList_ListView_SetUp();
+		}
+
+		void ModsList_ListView_SetUp()
+		{
+			//ListViewの初期化
+			ModsList_ListView.Items.Clear();
+
+			//ディレクトリが存在しないなら作る.
+			Directory.CreateDirectory(@"mods");
+
+
+			//ref : https://dobon.net/vb/dotnet/file/getfiles.html
+			var items = Directory.GetFiles(@"mods\", "*.dll", SearchOption.TopDirectoryOnly);
+
+			if(items.Length<=0)
+			{
+				Task.Run(() => MessageBox.Show("modがmodsフォルダに見当たりませんでした."));//ウィンドウは確実に表示する.
+				return;
+			}
+
+			//ref : https://dobon.net/vb/dotnet/file/fileversion.html
+			//ref : https://qiita.com/Kosen-amai/items/def339ea71cc69eeb9d0
+			List<FileVersionInfo> fvil = new List<FileVersionInfo>();
+			foreach (var item in items)
+			{
+				var fv = FileVersionInfo.GetVersionInfo(item);
+				if (fv != null)
+					fvil.Add(fv);
+			}
+
+			ModsList_ListView.DataContext = fvil;
+
+			if (fvil.Count > 0)
+				ModsList_ListView.SelectedIndex = 0;
+			else
+				Task.Run(() => MessageBox.Show("modがmodsフォルダに見当たりませんでした."));//ウィンドウは確実に表示する.
+		}
+
+
+		/*ISelectorの実装*/
+
+		public Page FrontPage => this;
+
+		public event EventHandler BackToHome;
+		public event EventHandler CloseApp;
+		public event EventHandler<PageChangeEventArgs> PageChangeRequest;
+
+		public void Dispose()
+		{
+		}
+
+		private void BackBtn_Click(object sender, RoutedEventArgs e) => BackToHome?.Invoke(this, null);
+
+		private void CloseBtn_Click(object sender, RoutedEventArgs e) => CloseApp?.Invoke(this, null);
+
+		private void LoadBtn_Click(object sender, RoutedEventArgs e)
+		{
+			SelectedPath = (ModsList_ListView.SelectedItem as FileVersionInfo).FileName;
+
+			if (string.IsNullOrWhiteSpace(SelectedPath))
+			{
+				MessageBox.Show("modの指定がされていません.");
+				return;
+			}
+
+			PageChangeRequest?.Invoke(this, new PageChangeEventArgs() { ModPath = SelectedPath });
+		}
+	}
+}

--- a/caMon.selector.default/caMon.selector.default.csproj
+++ b/caMon.selector.default/caMon.selector.default.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
+		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<UseWPF>true</UseWPF>
+		<Authors>Tetsu Otter</Authors>
+		<Company>Tech Otter</Company>
+		<Product>BIDS Project</Product>
+		<Copyright>Copyright 2020 Tetsu Otter</Copyright>
+		<PackageLicenseFile>LICENSE</PackageLicenseFile>
+		<RootNamespace>caMon.selector.default_</RootNamespace>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\caMon.IPages\caMon.IPages.csproj" />
+		<ProjectReference Include="..\caMon.ISelector\caMon.ISelector.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="..\LICENSE">
+			<Pack>True</Pack>
+			<PackagePath></PackagePath>
+		</None>
+	</ItemGroup>
+
+</Project>

--- a/caMon.sln
+++ b/caMon.sln
@@ -9,7 +9,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "caMon.pages.e233sp", "caMon
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "caMon", "caMon\caMon.csproj", "{B690E22D-6D28-4EE3-80CD-6A71FDA89B22}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "caMon.pages.e235sp", "caMon.pages.e235sp\caMon.pages.e235sp.csproj", "{954403F4-3C4C-445E-A0E8-1E573D8A7479}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "caMon.pages.e235sp", "caMon.pages.e235sp\caMon.pages.e235sp.csproj", "{954403F4-3C4C-445E-A0E8-1E573D8A7479}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "caMon.selector.default", "caMon.selector.default\caMon.selector.default.csproj", "{A76993D4-E97A-483B-85D2-1917EC972B15}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "caMon.ISelector", "caMon.ISelector\caMon.ISelector.csproj", "{17E993A2-BA0B-454F-9324-C156A9872BC0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,6 +37,14 @@ Global
 		{954403F4-3C4C-445E-A0E8-1E573D8A7479}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{954403F4-3C4C-445E-A0E8-1E573D8A7479}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{954403F4-3C4C-445E-A0E8-1E573D8A7479}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A76993D4-E97A-483B-85D2-1917EC972B15}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A76993D4-E97A-483B-85D2-1917EC972B15}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A76993D4-E97A-483B-85D2-1917EC972B15}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A76993D4-E97A-483B-85D2-1917EC972B15}.Release|Any CPU.Build.0 = Release|Any CPU
+		{17E993A2-BA0B-454F-9324-C156A9872BC0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{17E993A2-BA0B-454F-9324-C156A9872BC0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{17E993A2-BA0B-454F-9324-C156A9872BC0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{17E993A2-BA0B-454F-9324-C156A9872BC0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/caMon/caMon.csproj
+++ b/caMon/caMon.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>icon_s.ico</ApplicationIcon>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     <Authors>Tetsu Otter</Authors>
     <Company>Tech Otter</Company>
     <Product>BIDS Project</Product>
@@ -23,8 +23,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\caMon.IPages\caMon.IPages.csproj" />
+    <ProjectReference Include="..\caMon.ISelector\caMon.ISelector.csproj" />
     <ProjectReference Include="..\caMon.pages.e233sp\caMon.pages.e233sp.csproj" />
     <ProjectReference Include="..\caMon.pages.e235sp\caMon.pages.e235sp.csproj" />
+    <ProjectReference Include="..\caMon.selector.default\caMon.selector.default.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
自由にページを追加できるように, selectorプロジェクトを追加.

ISelectorインターフェイスを用意し, caMon本体は起動中不変のセレクタを持つ.  
セレクタからmodのロードを行う.  ページ変更はcaMon本体で行うため, セレクタからcaMon本体にmodの情報を通知する必要がある.  通知の方法はpage自体の通知とmodへのパスの通知の2種類を用意した.

デフォルトのセレクタとしてcaMon.selector.defaultプロジェクトを用意し, 現段階ではそれを静的参照している.  
次回更新では, セレクタも設定ファイルや実行時引数による動的設定を可能にしたいほか, 実行時引数による指定のmodの読み込みも実装したい.